### PR TITLE
Add belongs_to :quest to GameSerializer, update spec

### DIFF
--- a/app/serializers/game_serializer.rb
+++ b/app/serializers/game_serializer.rb
@@ -1,4 +1,5 @@
 class GameSerializer
 	include FastJsonapi::ObjectSerializer
 	attributes :status, :starting_fen, :current_fen
+	belongs_to :quest
 end

--- a/spec/requests/api/v1/games_request_spec.rb
+++ b/spec/requests/api/v1/games_request_spec.rb
@@ -120,6 +120,14 @@ RSpec.describe 'Games API' do
         expect(parsed_response[:data][:attributes][:status]).to eq(game1.status)
         expect(parsed_response[:data][:attributes][:status]).to eq('in_progress')
         expect(parsed_response[:data][:attributes][:starting_fen]).to eq(game1.starting_fen)
+
+        expect(parsed_response[:data][:relationships]).to be_a Hash
+        expect(parsed_response[:data][:relationships]).to have_key :quest
+        expect(parsed_response[:data][:relationships][:quest]).to have_key :data
+        expect(parsed_response[:data][:relationships][:quest][:data]).to have_key :id
+        expect(parsed_response[:data][:relationships][:quest][:data][:id]).to be_a String
+        expect(parsed_response[:data][:relationships][:quest][:data]).to have_key :type
+        expect(parsed_response[:data][:relationships][:quest][:data][:type]).to eq("quest")
       end
     end
   end


### PR DESCRIPTION
## Purpose
- As noted in @aetzion1's [comment from #47](https://github.com/chessquest/chess-quest/pull/47#pullrequestreview-601372970), this PR adds a `belongs_to :quest` relationship to our backend GameSerializer. - This change will help us assign quest_id to Game POROs on the frontend. 
- Closes #53 