### PR TITLE
Api caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'rack-cors'
 gem 'fast_jsonapi'
 gem 'faraday'
 gem 'rails-erd'
+gem 'api_cache'
 
 group :development, :test do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    api_cache (0.3.0)
     arel (9.0.0)
     bootsnap (1.7.2)
       msgpack (~> 1.0)
@@ -238,6 +239,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  api_cache
   bootsnap (>= 1.1.0)
   capybara
   faraday

--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -1,4 +1,3 @@
-
 class Api::V1::GamesController < ApplicationController
 	def show
 		game = GamesFacade.find_game(params[:id])

--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -1,3 +1,4 @@
+
 class Api::V1::GamesController < ApplicationController
 	def show
 		game = GamesFacade.find_game(params[:id])

--- a/app/services/game_service.rb
+++ b/app/services/game_service.rb
@@ -1,10 +1,11 @@
+require 'rubygems'
+require 'api_cache'
+
 class GameService
 	class << self
 
 		def get_game_data(params)
-			response = conn.get("game") do |req|
-				req.params[:find_player] = params
-			end
+			response = APICache.get(conn.build_url.to_s + "game?find_player=#{params}")
 			parse(response)
 		end
 
@@ -15,7 +16,7 @@ class GameService
 		end
 
 		def parse(response)
-			JSON.parse(response.body, symbolize_names: true)
+			JSON.parse(response, symbolize_names: true)
 		end
 	end
 end


### PR DESCRIPTION
## Purpose
_This branch improves user experience by adding a failsafe for the external API which will rely on cached data if the API is down for 24 hours.  This gives us a timeframe to address the issue without affecting user experience.  Caching also reduces requests made by limiting requests to once per minute and drawing upon cached data if an additional request is made within that time period._

## Approach
_This branch adds the API Cache gem which caches all http requests made and draws upon the cache if multiple requests are made within a short time period or the endpoint does not return valid data._

#### Open Questions
We are not entirely sure if testing for the cache failsafe is necessary nor how to do it.


_Links to blog posts, patterns, libraries or addons used to solve this problem_

#### Blog Posts
- https://github.com/mloughran/api_cache Repo for the API Caching gem

