### PR TITLE
Increase timeout period to account for sleeping heroku dynos

### DIFF
--- a/app/services/game_service.rb
+++ b/app/services/game_service.rb
@@ -5,7 +5,7 @@ class GameService
 	class << self
 
 		def get_game_data(params)
-			response = APICache.get(conn.build_url.to_s + "game?find_player=#{params}")
+			response = APICache.get(conn.build_url.to_s + "game?find_player=#{params}", {timeout: 30})
 			parse(response)
 		end
 


### PR DESCRIPTION
## Purpose
- Increase cache API request timeout to 30 seconds from default 5 seconds